### PR TITLE
Do not report examples as non-list elements

### DIFF
--- a/test/test_convert_to_concept_generated.py
+++ b/test/test_convert_to_concept_generated.py
@@ -39,7 +39,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Nested sections not allowed in DITA, skipping...')
 
         self.assertFalse(concept.xpath('boolean(//section/section)'))
@@ -65,7 +65,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Non-list elements found in related links, skipping...')
 
         self.assertFalse(concept.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -92,7 +92,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Extra list elements found in related-links, skipping...')
 
         self.assertFalse(concept.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -114,7 +114,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertNotEqual(len(err), 0)
         self.assertIn('WARNING: No list elements found in related links', [m.message for m in err])
 
         self.assertFalse(concept.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -137,7 +137,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(concept.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -160,7 +160,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(concept.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -183,7 +183,7 @@ class TestDitaConvertToConcept(unittest.TestCase):
         concept = transform.to_concept_generated(xml)
         err  = transform.to_concept_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertTrue(concept.xpath('boolean(/concept/conbody/p[text()="Topic introduction"])'))

--- a/test/test_convert_to_reference_generated.py
+++ b/test/test_convert_to_reference_generated.py
@@ -39,7 +39,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Nested sections not allowed in DITA, skipping...')
 
         self.assertFalse(reference.xpath('boolean(//section/section)'))
@@ -65,7 +65,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Non-list elements found in related links, skipping...')
 
         self.assertFalse(reference.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -92,7 +92,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Extra list elements found in related-links, skipping...')
 
         self.assertFalse(reference.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -114,7 +114,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertNotEqual(len(err), 0)
         self.assertIn('WARNING: No list elements found in related links', [m.message for m in err])
 
         self.assertFalse(reference.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -137,7 +137,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(reference.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -160,7 +160,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(reference.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -183,7 +183,7 @@ class TestDitaConvertToReference(unittest.TestCase):
         reference = transform.to_reference_generated(xml)
         err  = transform.to_reference_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertTrue(reference.xpath('boolean(/reference/refbody/section/p[text()="Topic introduction"])'))

--- a/test/test_convert_to_task_generated.py
+++ b/test/test_convert_to_task_generated.py
@@ -72,7 +72,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, "WARNING: Unsupported title 'Unsupported title' found, skipping...")
 
         self.assertFalse(task.xpath('boolean(//p[@outputclass="title"])'))
@@ -98,7 +98,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, "WARNING: Extra example elements found, skipping...")
 
         self.assertFalse(task.xpath('boolean(//example[2])'))
@@ -122,7 +122,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Non-list elements found in steps, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -171,7 +171,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Extra list elements found in steps, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -193,7 +193,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertNotEqual(len(err), 0)
         self.assertIn('WARNING: No list elements found in steps', [m.message for m in err])
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -217,7 +217,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Non-list elements found in related links, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -244,7 +244,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Extra list elements found in related-links, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -266,7 +266,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertNotEqual(len(err), 0)
         self.assertIn('WARNING: No list elements found in related links', [m.message for m in err])
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -289,7 +289,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -312,7 +312,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertFalse(task.xpath('boolean(//*[text()="Unsupported content"])'))
@@ -335,7 +335,7 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         task = transform.to_task_generated(xml)
         err  = transform.to_task_generated.error_log
 
-        self.assertIsNotNone(err.last_error)
+        self.assertEqual(len(err), 1)
         self.assertEqual(err.last_error.message, 'WARNING: Unexpected content found in related-links, skipping...')
 
         self.assertTrue(task.xpath('boolean(/task/taskbody/context/p[text()="Topic introduction"])'))

--- a/test/test_convert_to_task_generated.py
+++ b/test/test_convert_to_task_generated.py
@@ -129,6 +129,28 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         self.assertTrue(task.xpath('boolean(/task/taskbody/context/p[text()="Topic introduction"])'))
         self.assertTrue(task.xpath('boolean(/task/taskbody/steps/step/cmd[text()="Task step"])'))
 
+    def test_example_after_procedure(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <title>Topic title</title>
+            <body>
+                <p outputclass="title"><b>Procedure</b></p>
+                <ol>
+                    <li>A step.</li>
+                </ol>
+                <example>
+                    <title>Example title</title>
+                    <p>An example</p>
+                </example>
+            </body>
+        </topic>
+        '''))
+
+        task = transform.to_task_generated(xml)
+        err  = transform.to_task_generated.error_log
+
+        self.assertEqual(len(err), 0)
+
     def test_extra_list_elements_in_procedure(self):
         xml = etree.parse(StringIO('''\
         <topic id="example-topic">

--- a/xslt/task-generated.xsl
+++ b/xslt/task-generated.xsl
@@ -170,7 +170,7 @@
       <xsl:if test="$contents[self::section]">
         <xsl:message terminate="yes">ERROR: Section not allowed in a DITA task</xsl:message>
       </xsl:if>
-      <xsl:if test="$contents[not(self::ol or self::ul)]">
+      <xsl:if test="$contents[not(self::ol or self::ul or self::example)]">
         <xsl:message terminate="no">WARNING: Non-list elements found in steps, skipping...</xsl:message>
       </xsl:if>
       <xsl:if test="$contents[self::ol or self::ul][2]">


### PR DESCRIPTION
In a generated tasks, if an example block directly follows the procedure, the `dita-convert` utility incorrectly issues the following warning despite not skipping any content:

```
file.dita: WARNING: Non-list elements found in steps, skipping...
```

This pull request fixes this issue and also corrects the tests to correctly count expected error and warning messages.

### Example AsciiDoc code

```asciidoc
:_mod-docs-content-type: PROCEDURE

[#task-id]
= Task title

.Procedure
. A step.

.Example title
====
An example.
====
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
