### PR TITLE
Add support for the stepxmp element

### DIFF
--- a/test/test_convert_to_task.py
+++ b/test/test_convert_to_task.py
@@ -176,6 +176,61 @@ class TestDitaConvertToTask(unittest.TestCase):
         self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info/p[text()="Step explanation"])'))
 
+    def test_task_stepxmp(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <title>Topic title</title>
+            <body>
+                <ol>
+                    <li>
+                        <p>Step introduction</p>
+                        <codeblock>Step code</codeblock>
+                        <example>Step example</example>
+                    </li>
+                </ol>
+            </body>
+        </topic>
+        '''))
+
+        task = transform.to_task(xml)
+
+        self.assertTrue(task.xpath('boolean(//steps/step/cmd[text()="Step introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[text()="Step example"])'))
+
+    def test_alternating_stepxmp(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <title>Topic title</title>
+            <body>
+                <ol>
+                    <li>
+                        <p>Step introduction</p>
+                        <codeblock>Step code</codeblock>
+                        <p>Step explanation</p>
+                        <example>
+                            <p>Example introduction</p>
+                            <codeblock>Example code</codeblock>
+                        </example>
+                        <p>Additional information</p>
+                        <example>Additional example</example>
+                        <p>Step summary</p>
+                    </li>
+                </ol>
+            </body>
+        </topic>
+        '''))
+
+        task = transform.to_task(xml)
+
+        self.assertTrue(task.xpath('boolean(//steps/step/cmd[text()="Step introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[1]/codeblock[text()="Step code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[1]/p[text()="Example introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[1]/codeblock[text()="Example code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[2]/p[text()="Additional information"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[2][text()="Additional example"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[3]/p[text()="Step summary"])'))
+
     def test_task_substeps(self):
         xml = etree.parse(StringIO('''\
         <topic id="example-topic">
@@ -209,18 +264,23 @@ class TestDitaConvertToTask(unittest.TestCase):
         <topic id="example-topic">
             <title>Topic title</title>
             <body>
+                <p outputclass="title"><b>Procedure</b></p>
                 <ol>
                     <li>
                         <p>Step introduction</p>
                         <codeblock>Step code</codeblock>
                         <p>Step explanation</p>
                         <ol>
-                            <li>First substeps</li>
+                            <li>
+                                <p>First substeps</p>
+                                <example>First substep example</example>
+                            </li>
                         </ol>
                         <p>Additional information</p>
                         <ol>
                             <li>Second substeps</li>
                         </ol>
+                        <example>Step example</example>
                         <p>Step summary</p>
                     </li>
                 </ol>
@@ -234,6 +294,8 @@ class TestDitaConvertToTask(unittest.TestCase):
         self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[1]/p[text()="Step explanation"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/substeps[1]/substep/cmd[text()="First substeps"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/substeps[1]/substep/stepxmp[text()="First substep example"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[2]/p[text()="Additional information"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/substeps[2]/substep/cmd[text()="Second substeps"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[text()="Step example"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[3]/p[text()="Step summary"])'))

--- a/test/test_convert_to_task_generated.py
+++ b/test/test_convert_to_task_generated.py
@@ -694,12 +694,16 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
                         <codeblock>Step code</codeblock>
                         <p>Step explanation</p>
                         <ol>
-                            <li>First substeps</li>
+                            <li>
+                                <p>First substeps</p>
+                                <example>First substep example</example>
+                            </li>
                         </ol>
                         <p>Additional information</p>
                         <ol>
                             <li>Second substeps</li>
                         </ol>
+                        <example>Step example</example>
                         <p>Step summary</p>
                     </li>
                 </ol>
@@ -713,8 +717,10 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[1]/p[text()="Step explanation"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/substeps[1]/substep/cmd[text()="First substeps"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/substeps[1]/substep/stepxmp[text()="First substep example"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[2]/p[text()="Additional information"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/substeps[2]/substep/cmd[text()="Second substeps"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[text()="Step example"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info[3]/p[text()="Step summary"])'))
 
     def test_link_without_text(self):

--- a/test/test_convert_to_task_generated.py
+++ b/test/test_convert_to_task_generated.py
@@ -596,6 +596,63 @@ class TestDitaConvertToTaskGenerated(unittest.TestCase):
         self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
         self.assertTrue(task.xpath('boolean(//steps/step/info/p[text()="Step explanation"])'))
 
+    def test_task_stepxmp(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <title>Topic title</title>
+            <body>
+                <p outputclass="title"><b>Procedure</b></p>
+                <ol>
+                    <li>
+                        <p>Step introduction</p>
+                        <codeblock>Step code</codeblock>
+                        <example>Step example</example>
+                    </li>
+                </ol>
+            </body>
+        </topic>
+        '''))
+
+        task = transform.to_task_generated(xml)
+
+        self.assertTrue(task.xpath('boolean(//steps/step/cmd[text()="Step introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info/codeblock[text()="Step code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[text()="Step example"])'))
+
+    def test_alternating_stepxmp(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <title>Topic title</title>
+            <body>
+                <p outputclass="title"><b>Procedure</b></p>
+                <ol>
+                    <li>
+                        <p>Step introduction</p>
+                        <codeblock>Step code</codeblock>
+                        <p>Step explanation</p>
+                        <example>
+                            <p>Example introduction</p>
+                            <codeblock>Example code</codeblock>
+                        </example>
+                        <p>Additional information</p>
+                        <example>Additional example</example>
+                        <p>Step summary</p>
+                    </li>
+                </ol>
+            </body>
+        </topic>
+        '''))
+
+        task = transform.to_task_generated(xml)
+
+        self.assertTrue(task.xpath('boolean(//steps/step/cmd[text()="Step introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[1]/codeblock[text()="Step code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[1]/p[text()="Example introduction"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[1]/codeblock[text()="Example code"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[2]/p[text()="Additional information"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/stepxmp[2][text()="Additional example"])'))
+        self.assertTrue(task.xpath('boolean(//steps/step/info[3]/p[text()="Step summary"])'))
+
     def test_task_substeps(self):
         xml = etree.parse(StringIO('''\
         <topic id="example-topic">

--- a/xslt/task-generated.xsl
+++ b/xslt/task-generated.xsl
@@ -72,11 +72,6 @@
     <xsl:message terminate="no">WARNING: Extra example elements found, skipping...</xsl:message>
   </xsl:template>
 
-  <!-- Issue a warning it a nested example has a title: -->
-  <xsl:template match="//ol//example/title">
-    <xsl:message terminate="no">WARNING: Title not allowed in DITA stepxmp, skipping...</xsl:message>
-  </xsl:template>
-
   <!-- Perform identity transformation: -->
   <xsl:template match="@*|node()">
     <xsl:copy>
@@ -183,6 +178,9 @@
       </xsl:if>
       <xsl:if test="not($list)">
         <xsl:message terminate="no">WARNING: No list elements found in steps</xsl:message>
+      </xsl:if>
+      <xsl:if test="$contents//example/title">
+        <xsl:message terminate="no">WARNING: Title found in stepxmp, skipping...</xsl:message>
       </xsl:if>
       <xsl:if test="$list">
         <xsl:variable name="name">
@@ -329,7 +327,7 @@
       <xsl:variable name="current-position" select="position()" />
       <xsl:call-template name="compose-element">
         <xsl:with-param name="name" select="'stepxmp'" />
-        <xsl:with-param name="contents" select="text()|*" />
+        <xsl:with-param name="contents" select="text()|*[not(self::title)]" />
       </xsl:call-template>
       <xsl:choose>
         <xsl:when test="following-sibling::example">

--- a/xslt/task.xsl
+++ b/xslt/task.xsl
@@ -138,6 +138,9 @@
   <xsl:template name="steps">
     <xsl:param name="steps" />
     <xsl:if test="$steps">
+      <xsl:if test="$steps//example/title">
+        <xsl:message terminate="no">WARNING: Title found in stepxmp, skipping...</xsl:message>
+      </xsl:if>
       <xsl:element name="steps">
         <xsl:for-each select="$steps/li">
           <xsl:call-template name="step-substep">
@@ -245,8 +248,7 @@
         </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:call-template name="compose-element">
-          <xsl:with-param name="name" select="'info'" />
+        <xsl:call-template name="info-stepxmp">
           <xsl:with-param name="contents" select="$contents" />
         </xsl:call-template>
       </xsl:otherwise>
@@ -259,14 +261,12 @@
     <xsl:variable name="substeps-count" select="count($contents[self::ol])" />
     <xsl:variable name="first-info" select="$contents[following-sibling::ol[$substeps-count]]" />
     <xsl:if test="$substeps-count = 0">
-      <xsl:call-template name="compose-element">
-        <xsl:with-param name="name" select="'info'" />
+      <xsl:call-template name="info-stepxmp">
         <xsl:with-param name="contents" select="$contents" />
       </xsl:call-template>
     </xsl:if>
     <xsl:if test="$first-info">
-      <xsl:call-template name="compose-element">
-        <xsl:with-param name="name" select="'info'" />
+      <xsl:call-template name="info-stepxmp">
         <xsl:with-param name="contents" select="$first-info" />
       </xsl:call-template>
     </xsl:if>
@@ -281,13 +281,54 @@
       </xsl:element>
       <xsl:choose>
         <xsl:when test="following-sibling::ol">
-          <xsl:call-template name="compose-element">
-            <xsl:with-param name="name" select="'info'" />
+          <xsl:call-template name="info-stepxmp">
             <xsl:with-param name="contents" select="following-sibling::*[following-sibling::ol[$substeps-count - $current-position]]" />
           </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>
           <xsl:variable name="last-info" select="following-sibling::*|following-sibling::text()" />
+          <xsl:if test="$last-info">
+            <xsl:call-template name="info-stepxmp">
+              <xsl:with-param name="contents" select="$last-info" />
+            </xsl:call-template>
+          </xsl:if>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
+
+  <!-- Compose alternating info/stepxmp elements: -->
+  <xsl:template name="info-stepxmp">
+    <xsl:param name="contents" />
+    <xsl:variable name="xmp-count" select="count($contents[self::example])" />
+    <xsl:variable name="first-info" select="$contents[following-sibling::example[$xmp-count]]" />
+    <xsl:if test="$xmp-count = 0">
+      <xsl:call-template name="compose-element">
+        <xsl:with-param name="name" select="'info'" />
+        <xsl:with-param name="contents" select="$contents" />
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:if test="$first-info">
+      <xsl:call-template name="compose-element">
+        <xsl:with-param name="name" select="'info'" />
+        <xsl:with-param name="contents" select="$first-info" />
+      </xsl:call-template>
+    </xsl:if>
+    <xsl:for-each select="$contents[self::example]">
+      <xsl:variable name="current-position" select="position()" />
+      <xsl:call-template name="compose-element">
+        <xsl:with-param name="name" select="'stepxmp'" />
+        <xsl:with-param name="contents" select="text()|*[not(self::title)]" />
+      </xsl:call-template>
+      <xsl:choose>
+        <xsl:when test="following-sibling::example">
+          <xsl:call-template name="compose-element">
+            <xsl:with-param name="name" select="'info'" />
+            <xsl:with-param name="contents" select="following-sibling::*[following-sibling::example[$xmp-count - $current-position]]" />
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:variable name="last-info" select="following-sibling::*[not(self::ol)]|following-sibling::text()" />
           <xsl:if test="$last-info">
             <xsl:call-template name="compose-element">
               <xsl:with-param name="name" select="'info'" />


### PR DESCRIPTION
DITA 1.3 supports the `<stepxmp>` element which can be used to provide an example usage of a step. While this element does not allow titles like `<example>`, `<stepxmp>` is the logical choice for AsciiDoc example blocks inside of procedure steps.

Note: If this approach works, it should be applied to both `task-generated.xsl` and `task.xsl`.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
