### PR TITLE
Do not skip files when the outputclass attribute is missing

### DIFF
--- a/src/dita/convert/cli.py
+++ b/src/dita/convert/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2024, 2025 Jaromir Hradilek
+# Copyright (C) 2024-2026 Jaromir Hradilek
 
 # MIT License
 #
@@ -84,6 +84,9 @@ def fix_element_outputclass(xml_element: etree._Element) -> None:
 
 # Extract the content type from the root element outputclass:
 def get_type(source_file: str, source_xml: etree._ElementTree) -> str:
+    # Define the content type to fall back to:
+    default_type = 'concept'
+
     # Get the root element and its attributes:
     root_element = source_xml.getroot()
     attributes   = source_xml.getroot().attrib
@@ -94,7 +97,8 @@ def get_type(source_file: str, source_xml: etree._ElementTree) -> str:
 
     # Verify that the outputclass attribute is defined:
     if 'outputclass' not in attributes:
-        raise Exception(f'error: outputclass not found, use -t/--type')
+        warn(f'warning: outputclass not found, using "{default_type}"', source_file)
+        return default_type
 
     # Get the outputclass attribute value:
     output_class = str(attributes['outputclass'].lower())

--- a/test/test_convert_cli.py
+++ b/test/test_convert_cli.py
@@ -512,10 +512,11 @@ class TestDitaCli(unittest.TestCase):
     def test_get_type_missing(self):
         xml = etree.parse(StringIO('<topic />'))
 
-        with self.assertRaises(Exception) as cm:
+        with contextlib.redirect_stderr(StringIO()) as err:
             target_type = cli.get_type('topic.dita', xml)
 
-        self.assertRegex(str(cm.exception), r'error: outputclass not found')
+        self.assertRegex(err.getvalue(), r'warning: outputclass not found')
+        self.assertEqual(target_type, 'concept')
 
     def test_get_type_invalid(self):
         xml = etree.parse(StringIO('<topic outputclass="snippet" />'))


### PR DESCRIPTION
Especially when converting large number of files, having `dita-convert` skip over files that do not have the `@outputclass` attribute defined is unpleasant. With this update, `dita-convert` issues a warning and converts any files with undefined `@outputclass` to concept topics.

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
