### PR TITLE
Prevent empty sections in generated reference topics

### DIFF
--- a/test/test_convert_to_reference_generated.py
+++ b/test/test_convert_to_reference_generated.py
@@ -276,9 +276,13 @@ class TestDitaConvertToReference(unittest.TestCase):
         '''))
 
         reference = transform.to_reference_generated(xml)
+        err       = transform.to_reference_generated.error_log
+
+        self.assertEqual(len(err), 1)
+        self.assertEqual(err.last_error.message, 'WARNING: Extra short description found, skipping...')
 
         self.assertTrue(reference.xpath('boolean(/reference/shortdesc[text()="Topic abstract"])'))
-        self.assertTrue(reference.xpath('boolean(/reference/refbody/section/p[text()="Topic introduction"])'))
+        self.assertFalse(reference.xpath('boolean(/reference/refbody/section/p[text()="Topic introduction"])'))
         self.assertFalse(reference.xpath('boolean(/reference/shortdesc[text()="Topic introduction"])'))
         self.assertFalse(reference.xpath('boolean(/reference/refbody/section/p[text()="Topic abstract"])'))
 

--- a/test/test_convert_to_reference_generated.py
+++ b/test/test_convert_to_reference_generated.py
@@ -303,6 +303,56 @@ class TestDitaConvertToReference(unittest.TestCase):
         self.assertFalse(reference.xpath('boolean(/reference/shortdesc[text()="Topic introduction"])'))
         self.assertFalse(reference.xpath('boolean(/reference/refbody/section/p[text()="Topic abstract"])'))
 
+    def test_no_content(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <body>
+                <p outputclass="abstract">Topic abstract</p>
+            </body>
+        </topic>
+        '''))
+
+        reference = transform.to_reference_generated(xml)
+
+        self.assertTrue(reference.xpath('boolean(/reference/shortdesc[text()="Topic abstract"])'))
+        self.assertEqual(reference.xpath('count(/reference/refbody/section)'), 0)
+
+    def test_no_content_before_section(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <body>
+                <p outputclass="abstract">Topic abstract</p>
+                <section id="section-id">
+                    <p>A paragraph.</p>
+                </section>
+            </body>
+        </topic>
+        '''))
+
+        reference = transform.to_reference_generated(xml)
+
+        self.assertTrue(reference.xpath('boolean(/reference/shortdesc[text()="Topic abstract"])'))
+        self.assertTrue(reference.xpath('boolean(/reference/refbody/section[1][@id="section-id"])'))
+        self.assertEqual(reference.xpath('count(/reference/refbody/section)'), 1)
+
+    def test_no_content_before_example(self):
+        xml = etree.parse(StringIO('''\
+        <topic id="example-topic">
+            <body>
+                <p outputclass="abstract">Topic abstract</p>
+                <example id="example-id">
+                    <p>A paragraph.</p>
+                </example>
+            </body>
+        </topic>
+        '''))
+
+        reference = transform.to_reference_generated(xml)
+
+        self.assertTrue(reference.xpath('boolean(/reference/shortdesc[text()="Topic abstract"])'))
+        self.assertTrue(reference.xpath('boolean(/reference/refbody/example[@id="example-id"])'))
+        self.assertEqual(reference.xpath('count(/reference/refbody/section)'), 0)
+
     def test_link_without_text(self):
         xml = etree.parse(StringIO('''\
         <topic id="example-topic">

--- a/xslt/reference-generated.xsl
+++ b/xslt/reference-generated.xsl
@@ -84,8 +84,11 @@
     </xsl:call-template>
     <!-- Compose the refbody element: -->
     <xsl:element name="refbody">
+      <xsl:if test="p[@outputclass='abstract'][2]">
+        <xsl:message terminate="no">WARNING: Extra short description found, skipping...</xsl:message>
+      </xsl:if>
       <xsl:call-template name="example-section">
-        <xsl:with-param name="contents" select="@*|node()" />
+        <xsl:with-param name="contents" select="@*|node()[not(self::p[@outputclass='abstract'])]" />
       </xsl:call-template>
     </xsl:element>
     <!-- Compose the related-links element: -->


### PR DESCRIPTION
Because the paragraph marked as the abstract is initially present in the main body of the topic before being transformed into the `<shortdesc>` element, `dita-convert` previously created empty sections in reference modules when no other paragraph followed this abstract. This pull request corrects this behavior.

### Example AsciiDoc code

```asciidoc
:_mod-docs-content-type: REFERENCE

= A topic title

[role="_abstract"]
A short description

== A section title

A paragraph.
```

### Previous DITA output

```xml
<?xml version="1.0"?>
<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
<reference id="topic-99c100c5-2a68-49ec-ab97-36af307ee5b4">
  <title>A topic title</title>
  <shortdesc>A short description</shortdesc>
  <refbody>
    <section/>
    <section id="_a_section_title">
      <title>A section title</title>
      <p>A paragraph.</p>
    </section>
  </refbody>
</reference>
```

### Corrected DITA output

```xml
<?xml version="1.0"?>
<!DOCTYPE reference PUBLIC "-//OASIS//DTD DITA Reference//EN" "reference.dtd">
<reference id="topic-31716f66-671f-4dd3-a81e-3a0f16424d5c">
  <title>A topic title</title>
  <shortdesc>A short description</shortdesc>
  <refbody>
    <section id="_a_section_title">
      <title>A section title</title>
      <p>A paragraph.</p>
    </section>
  </refbody>
</reference>
```

### Implementation checklist

- [x] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
