### PR TITLE
Include section IDs in warnings when splitting a topic

### DIFF
--- a/src/dita/convert/cli.py
+++ b/src/dita/convert/cli.py
@@ -266,19 +266,20 @@ def split_topics(args: argparse.Namespace) -> int:
                 if parent is not None:
                     parent.remove(e)
 
+            # Compose the target file path:
+            element_id  = str(element.attrib["id"])
+            output_file = str(os.path.join(args.directory, element_id + '.dita'))
+
             try:
                 # Convert the selected file in nested topics:
-                out = convert(input_file, topic, None, args.generated)
+                out = convert(f'{input_file} (id="{element_id}")', topic, None, args.generated)
             except etree.XSLTApplyError as message:
                 # Report the error:
-                warn(f'error: {message}', input_file)
+                warn(f'error: {message}', f'{input_file} (id="{element_id}")')
 
                 # Do not proceed further with this file:
                 exit_code = errno.EPERM
                 continue
-
-            # Compose the target file path:
-            output_file = str(os.path.join(args.directory, str(element.attrib["id"]) + '.dita'))
 
             try:
                 # Write the converted content to the selected file:


### PR DESCRIPTION
The current version of `dita-convert` only lists the source file name in error and warning messages. This makes sense in normal operation, but when using the `-s` option to split a large monolithic topic, the lack of further information makes it difficult to find and correct the problems:

```console
$ dita-convert -gsd out master.dita
dita-convert: master.dita: WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita: WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita: WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita: WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita: WARNING: Non-list elements found in steps, skipping...
```

This pull request adjusts the error and warning messages to include the section ID as well:

```console
$ dita-convert -gsd out master.dita
dita-convert: master.dita (id="uefi-secure-boot-and-beta-release-requirements_system-requirements-and-supported-architectures"): WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita (id="creating-a-bootable-usb-mac_assembly_creating-a-bootable-installation-medium"): WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita (id="installing-under-kvm_rhel-installer"): WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita (id="proc_editing-the-boot-prompt-in-bios_optional-customizing-boot-options"): WARNING: Unexpected content found in related-links, skipping...
dita-convert: master.dita (id="starting-an-iscsi-session_storage-devices"): WARNING: Non-list elements found in steps, skipping...
```

### Implementation checklist

- [ ] The code changes come with the corresponding test cases
- [x] The code changes pass all tests (run `python3 -m unittest` in the project directory)
- [ ] The code changes come with appropriate documentation
